### PR TITLE
Bind CursorMoved event only to the current buffer

### DIFF
--- a/autoload/quickui/preview.vim
+++ b/autoload/quickui/preview.vim
@@ -161,7 +161,7 @@ function! quickui#preview#display(content, opts)
 	let s:private.state = 1
 	if has('nvim')
 		if get(a:opts, 'persist', 0) == 0
-			autocmd CursorMoved * ++once call s:nvim_autocmd()
+			autocmd CursorMoved <buffer> ++once call s:autoclose_preview_window()
 		endif
 	endif
 	return winid
@@ -209,7 +209,7 @@ endfunc
 "----------------------------------------------------------------------
 " quit
 "----------------------------------------------------------------------
-function! s:nvim_autocmd()
+function! s:autoclose_preview_window()
 	if s:private.state != 0
 		if s:private.winid >= 0
 			call quickui#preview#close()


### PR DESCRIPTION
Previously the CursorMoved event used to auto-close the popup window
was bounded globally, so when a cursor is to moved in another window
or even when the popup window gets a focus, the popup window would be
closed. This makes impossible to move the cursor to the popup window.

With the event bounded only to the current buffer, we can fix this problem.

A related issue: #9