### PR TITLE
new feature: Using relative number to accelerate locating options. (vim only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,3 @@
-# About this fork
-With more and more options added, I want more efficient way to locate
-the command.
-
-I am trying to add relative number to this plugin. If you've used the
-"relativenumber" of vim before, you'll be familiar with it.
-
-As so far, preliminary supports for these widgets are available. (vim only)
-* Menu
-* Context menu
-
-Known bugs:
-* [] Not compatible with neovim. (need help)
-* [fixed] The highlight of the first letter in sub menu is occupied by line number.
-* [fixed] unexpected cursor move will occur when following the order of these operations.
-    1) opening context menu.
-    2) locating the comand by relative number(The larger the number,
-        the more obvious the effect).
-    3) closing the context menu.
-    4) pressing j or k
-
-Maybe More:
-* second menu for context menu
-
-Bug reports are welcome.
-
-
 # What Is It ?
 
 There are many keymaps defined in my `.vimrc`. Getting tired from checking `.vimrc` time to time when I forget some, based on latest `+popup` feature (vim 8.2), I created this `vim-quickui` plugin to introduce some basic ui components to enrich vim's interactive experience:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # About this fork
-With more and more opotions added, I want more efficient way to locate
+With more and more options added, I want more efficient way to locate
 the command.
 
 I am trying to add relative number to this plugin. If you've used the
-relativenumber of vim before, you'll be familiar with it.
+"relativenumber" of vim before, you'll be familiar with it.
 
-As so far, preliminary supports for these widgets are available. (vim olny)
+As so far, preliminary supports for these widgets are available. (vim only)
 * Menu
 * Context menu
 
 Known bugs:
-* The highlight of the first letter in sub menu is occupied by line number.
-* unexpected cursor move will occur when following the order of these operations.
+* [fixed] The highlight of the first letter in sub menu is occupied by line number.
+* [fixed] unexpected cursor move will occur when following the order of these operations.
     1) opening context menu.
     2) locating the comand by relative number(The larger the number,
         the more obvious the effect).
     3) closing the context menu.
     4) pressing j or k
+
+Bug reports are welcome.
 
 
 # What Is It ?

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ the command.
 I am trying to add relative number to this plugin. If you've used the
 relativenumber of vim before, you'll be familiar with it.
 
-As so far, preliminary supports for these widgets are available.
+As so far, preliminary supports for these widgets are available. (vim olny)
 * Menu
 * Context menu
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+# About this fork
+With more and more opotions added, I want more efficient way to locate
+the command.
+I am trying to add relative number to this plugin. If you've used the
+relativenumber of vim before, you'll be familiar with it.
+As so far, preliminary supports for these widgets are available.
+* Menu
+* Context menu
+Known bugs:
+* The highlight of the first letter in sub menu is occupied by line number.
+* unexpected cursor move will occur when following the order of these operations.
+    1) opening context menu.
+    2) locating the comand by relative number(The larger the number,
+        the more obvious the effect).
+    3) closing the context menu.
+
+
 # What Is It ?
 
 There are many keymaps defined in my `.vimrc`. Getting tired from checking `.vimrc` time to time when I forget some, based on latest `+popup` feature (vim 8.2), I created this `vim-quickui` plugin to introduce some basic ui components to enrich vim's interactive experience:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ As so far, preliminary supports for these widgets are available. (vim only)
 * Context menu
 
 Known bugs:
+* [] Not compatible with neovim. (need help)
 * [fixed] The highlight of the first letter in sub menu is occupied by line number.
 * [fixed] unexpected cursor move will occur when following the order of these operations.
     1) opening context menu.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Known bugs:
     3) closing the context menu.
     4) pressing j or k
 
+Maybe More:
+* second menu for context menu
+
 Bug reports are welcome.
 
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ relativenumber of vim before, you'll be familiar with it.
 As so far, preliminary supports for these widgets are available.
 * Menu
 * Context menu
+
 Known bugs:
 * The highlight of the first letter in sub menu is occupied by line number.
 * unexpected cursor move will occur when following the order of these operations.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # About this fork
 With more and more opotions added, I want more efficient way to locate
 the command.
+
 I am trying to add relative number to this plugin. If you've used the
 relativenumber of vim before, you'll be familiar with it.
+
 As so far, preliminary supports for these widgets are available.
 * Menu
 * Context menu
@@ -14,6 +16,7 @@ Known bugs:
     2) locating the comand by relative number(The larger the number,
         the more obvious the effect).
     3) closing the context menu.
+    4) pressing j or k
 
 
 # What Is It ?

--- a/README.md
+++ b/README.md
@@ -1,27 +1,3 @@
-=======
-# About this fork
-An awesome plugin with awesome modifications to meet individual needs.
-
-What is new:
-* Relative number for menu and context menu. (vim only)
-
-Maybe more:
-* second menu for context menu.
-
-Disable the relative number.
-> let g:quickui_enable_rnu = 0
-
-Known bugs:
-* [fixed] The highlight of the first letter in sub menu is occupied by line number.
-* [fixed] unexpected cursor move will occur when following the order of these operations.
-    1) opening context menu.
-    2) locating the comand by relative number(The larger the number,
-        the more obvious the effect).
-    3) closing the context menu.
-    4) pressing j or k
-
-Bug reports are welcome.
-
 # What Is It ?
 
 There are many keymaps defined in my `.vimrc`. Getting tired from checking `.vimrc` time to time when I forget some, based on latest `+popup` feature (vim 8.2), I created this `vim-quickui` plugin to introduce some basic ui components to enrich vim's interactive experience:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 =======
 # About this fork
 An awesome plugin with awesome modifications to meet individual needs.
@@ -23,8 +22,6 @@ Known bugs:
 
 Bug reports are welcome.
 
-
->>>>>>> nightly
 # What Is It ?
 
 There are many keymaps defined in my `.vimrc`. Getting tired from checking `.vimrc` time to time when I forget some, based on latest `+popup` feature (vim 8.2), I created this `vim-quickui` plugin to introduce some basic ui components to enrich vim's interactive experience:

--- a/autoload/quickui/context.vim
+++ b/autoload/quickui/context.vim
@@ -385,7 +385,7 @@ function! s:popup_filter(winid, key)
             else
                 let s:mc_rept = a:key
             endif
-            return
+            return 1
 		endif
         let s:mc_rept = 0   " clean anyway "
 

--- a/autoload/quickui/context.vim
+++ b/autoload/quickui/context.vim
@@ -174,8 +174,9 @@ function! quickui#context#update(hwnd)
         let tmp = a:hwnd.index
         let cnt = 0
         if tmp >= 0
+            let size = len(a:hwnd.image)
             for i in range(tmp)
-                if match(a:hwnd.image[i+1], s:place_holder) == -1
+                if i+1 < size && match(a:hwnd.image[i+1], s:place_holder) == -1
                     let cnt += 1
                 endif
             endfor

--- a/autoload/quickui/context.vim
+++ b/autoload/quickui/context.vim
@@ -387,6 +387,8 @@ function! s:popup_filter(winid, key)
                 let s:mc_rept = a:key
             endif
             return 1
+        elseif key == 'LEFT' || key == 'RIGHT'
+            let g:quickui_rept = s:mc_rept
 		endif
         let s:mc_rept = 0   " clean anyway "
 

--- a/autoload/quickui/context.vim
+++ b/autoload/quickui/context.vim
@@ -177,6 +177,9 @@ endfunc
 "----------------------------------------------------------------------
 function! quickui#context#update(hwnd)
     function! RenderContext(hwnd)
+		if g:quickui#core#has_nvim == 1
+            return
+        endif
         let tmp = a:hwnd.index
         let cnt = 0
         if tmp >= 0
@@ -755,9 +758,9 @@ endfunc
 " is_drop: 1 -> opened by menu
 "          0 -> opened not by menu
 "----------------------------------------------------------------------
-function! quickui#context#open(textlist, opts, is_drop = 0)
+function! quickui#context#open(textlist, opts)
     let s:mc_rept = 0
-    let s:is_drop = a:is_drop
+    let s:is_drop = get(a:opts, 'is_drop', 0)
 	let textlist = a:textlist
 	if g:quickui#core#has_nvim == 0
 		return s:vim_create_context(textlist, a:opts)

--- a/autoload/quickui/menu.vim
+++ b/autoload/quickui/menu.vim
@@ -275,11 +275,12 @@ function! s:parse_menu(name, padding)
 	let names = quickui#menu#available(a:name)
 	let index = 0
 	let size = len(names)
+    let place_holder = (g:quickui#core#has_nvim == 1)? ' ' : '#'
 	for section in names
 		let menu = current[section]
 		let item = {'name':menu.name, 'text':''}
 		let obj = quickui#core#escape(menu.name)
-		let item.text = '#' . obj[0] . ' '
+		let item.text = place_holder . obj[0] . ' '
 		let item.key_char = obj[1]
 		let item.key_pos = (obj[4] < 0)? -1 : (obj[4] + 1)
 		let item.x = start
@@ -368,6 +369,9 @@ endfunc
 "----------------------------------------------------------------------
 function! quickui#menu#update()
     function! RenderIndx()
+		if g:quickui#core#has_nvim == 1
+            return
+        endif
         let start = s:cmenu.index
         let menu = s:cmenu.inst.text
         let size = s:cmenu.size
@@ -574,7 +578,8 @@ function! s:context_dropdown()
 	let index = get(cfg, 'index', 0)
 	let opts.index = (index < 0 || index >= len(cfg.items))? 0 : index
 	let cfg.index = opts.index
-	let hwnd = quickui#context#open(s:cmenu.dropdown, opts, 1)
+    let opts.is_drop = 1
+    let hwnd = quickui#context#open(s:cmenu.dropdown, opts)
 	let s:cmenu.context = hwnd.winid
 	let s:cmenu.state = 1
 endfunc
@@ -661,6 +666,7 @@ function! s:neovim_dropdown()
 	let index = get(cfg, 'index', 0)
 	let opts.index = (index < 0 || index >= len(cfg.items))? 0 : index
 	let cfg.index = opts.index
+    let opts.is_drop = 1
 	let hr = quickui#context#open(s:cmenu.dropdown, opts)
 	let cfg.index = g:quickui#context#current.index
 	let s:cmenu.next = 0

--- a/autoload/quickui/menu.vim
+++ b/autoload/quickui/menu.vim
@@ -17,7 +17,7 @@ let s:namespace = { 'system':{'config':{}, 'weight':100, 'index':0} }
 let s:name = 'system'
 
 " the number pressed by user "
-let g:quickui_rept = 0
+let g:menu_rept = 0
 
 
 "----------------------------------------------------------------------
@@ -358,7 +358,7 @@ function! quickui#menu#create(opts)
 	call popup_show(winid)
 
     " after menu created, rept must be 0 "
-    let g:quickui_rept = 0
+    let g:menu_rept = 0
 	return 0
 endfunc
 
@@ -482,17 +482,17 @@ function! s:movement(key, ...)
 		if index < 0
 			let index = 0
 		elseif a:key == 'LEFT'
-            let offset = (g:quickui_rept - 1 < 0)? 0 : (g:quickui_rept - 1)
+            let offset = (g:menu_rept - 1 < 0)? 0 : (g:menu_rept - 1)
 			let index = index - 1 - offset
 		elseif a:key == 'RIGHT'
-            let offset = (g:quickui_rept - 1 < 0)? 0 : (g:quickui_rept - 1)
+            let offset = (g:menu_rept - 1 < 0)? 0 : (g:menu_rept - 1)
 			let index = index + 1 + offset
         elseif a:key == 'HOLD'
-            if g:quickui_rept != 0
+            if g:menu_rept != 0
                 " the index is greater than 9 "
-                let g:quickui_rept = g:quickui_rept * 10 + btn
+                let g:menu_rept = g:menu_rept * 10 + btn
             else
-                let g:quickui_rept = btn
+                let g:menu_rept = btn
             endif
             return
 		endif
@@ -512,7 +512,7 @@ function! s:movement(key, ...)
 			return s:neovim_dropdown()
 		endif
 	endif
-    let g:quickui_rept = 0   " clean anyway "
+    let g:menu_rept = 0   " clean anyway "
 endfunc
 
 
@@ -574,7 +574,7 @@ function! s:context_dropdown()
 	let index = get(cfg, 'index', 0)
 	let opts.index = (index < 0 || index >= len(cfg.items))? 0 : index
 	let cfg.index = opts.index
-	let hwnd = quickui#context#open(s:cmenu.dropdown, opts)
+	let hwnd = quickui#context#open(s:cmenu.dropdown, opts, 1)
 	let s:cmenu.context = hwnd.winid
 	let s:cmenu.state = 1
 endfunc

--- a/autoload/quickui/menu.vim
+++ b/autoload/quickui/menu.vim
@@ -15,6 +15,8 @@
 "----------------------------------------------------------------------
 let s:namespace = { 'system':{'config':{}, 'weight':100, 'index':0} }
 let s:name = 'system'
+
+" the number pressed by user "
 let g:quickui_rept = 0
 
 
@@ -480,11 +482,18 @@ function! s:movement(key, ...)
 		if index < 0
 			let index = 0
 		elseif a:key == 'LEFT'
-			let index = index - 1 - g:quickui_rept
+            let offset = (g:quickui_rept - 1 < 0)? 0 : (g:quickui_rept - 1)
+			let index = index - 1 - offset
 		elseif a:key == 'RIGHT'
-			let index = index + 1 + g:quickui_rept
+            let offset = (g:quickui_rept - 1 < 0)? 0 : (g:quickui_rept - 1)
+			let index = index + 1 + offset
         elseif a:key == 'HOLD'
-            let g:quickui_rept = (btn - 1) < 0 ? 0 : (btn - 1)
+            if g:quickui_rept != 0
+                " the index is greater than 9 "
+                let g:quickui_rept = g:quickui_rept * 10 + btn
+            else
+                let g:quickui_rept = btn
+            endif
             return
 		endif
 		let index = (index < 0)? (s:cmenu.size - 1) : index

--- a/autoload/quickui/utils.vim
+++ b/autoload/quickui/utils.vim
@@ -74,7 +74,7 @@ function! quickui#utils#item_parse(description)
 				let rest .= key
 			endif
 		endwhile
-		let obj.text = rest
+		let obj.text = "##".rest
 		let obj.text_width = strwidth(obj.text)
 		let obj.desc_width = strwidth(obj.desc)
 	end
@@ -171,6 +171,15 @@ let s:maps["G"] = 'BOTTOM'
 let s:maps['q'] = 'ESC'
 let s:maps['n'] = 'NEXT'
 let s:maps['N'] = 'PREV'
+let s:maps['1'] = 'HOLD'
+let s:maps['2'] = 'HOLD'
+let s:maps['3'] = 'HOLD'
+let s:maps['4'] = 'HOLD'
+let s:maps['5'] = 'HOLD'
+let s:maps['6'] = 'HOLD'
+let s:maps['7'] = 'HOLD'
+let s:maps['8'] = 'HOLD'
+let s:maps['9'] = 'HOLD'
 
 
 function! quickui#utils#keymap()

--- a/autoload/quickui/utils.vim
+++ b/autoload/quickui/utils.vim
@@ -52,7 +52,7 @@ function! quickui#utils#item_parse(description)
 			let obj.desc = strpart(text, pos + 1)
 			let obj.desc = substitute(obj.desc, "\t", " ", "g")
 		endif
-		let text = "## ".obj.text
+		let text = (g:quickui#core#has_nvim == 1)? obj.text : "## ".obj.text
 		let rest = ''
 		let start = 0
 		while 1

--- a/autoload/quickui/utils.vim
+++ b/autoload/quickui/utils.vim
@@ -52,7 +52,7 @@ function! quickui#utils#item_parse(description)
 			let obj.desc = strpart(text, pos + 1)
 			let obj.desc = substitute(obj.desc, "\t", " ", "g")
 		endif
-		let text = obj.text
+		let text = "## ".obj.text
 		let rest = ''
 		let start = 0
 		while 1
@@ -74,7 +74,7 @@ function! quickui#utils#item_parse(description)
 				let rest .= key
 			endif
 		endwhile
-		let obj.text = "## ".rest
+		let obj.text = rest
 		let obj.text_width = strwidth(obj.text)
 		let obj.desc_width = strwidth(obj.desc)
 	end

--- a/autoload/quickui/utils.vim
+++ b/autoload/quickui/utils.vim
@@ -74,7 +74,7 @@ function! quickui#utils#item_parse(description)
 				let rest .= key
 			endif
 		endwhile
-		let obj.text = "##".rest
+		let obj.text = "## ".rest
 		let obj.text_width = strwidth(obj.text)
 		let obj.desc_width = strwidth(obj.desc)
 	end
@@ -171,6 +171,7 @@ let s:maps["G"] = 'BOTTOM'
 let s:maps['q'] = 'ESC'
 let s:maps['n'] = 'NEXT'
 let s:maps['N'] = 'PREV'
+let s:maps['0'] = 'HOLD'
 let s:maps['1'] = 'HOLD'
 let s:maps['2'] = 'HOLD'
 let s:maps['3'] = 'HOLD'


### PR DESCRIPTION
This is a awesome plugin. I used it for a long time.

With more and more options added, A more efficient way to locate
the command would be nice.

Inspired by the "relativenumber" of vim, I decided to add this feature to the plugin.

The new feature supports these widgets. (vim only)
* Menu
* Context menu

I have tried to support nvim, but it is beyound my experience...