### PR TITLE
Support context menu entry filetype blacklist

### DIFF
--- a/autoload/quickui/context.vim
+++ b/autoload/quickui/context.vim
@@ -667,6 +667,10 @@ function! quickui#context#reduce_items(textlist)
 					let state = 0
 				else
 					for check in split(item[3], ',')
+						if '-'.&ft == check
+							break
+						endif
+
 						if &ft == check
 							let output += [item]
 							let state = 0


### PR DESCRIPTION
Entry like

`    \ [ "&Get Doc\t(YCM)", 'call YouCompleterShowPopup("GetDoc")', '', '-markdown' ],`

will not show on a `markdown` filetype buffer.