### PR TITLE
Fix #64

### DIFF
--- a/autoload/quickui/tools.vim
+++ b/autoload/quickui/tools.vim
@@ -14,8 +14,9 @@
 " list buffer ids
 "----------------------------------------------------------------------
 function! s:buffer_list()
+    let l:ls_cli = get(g:, 'quickui_buffer_list_cli', 'ls t')
     redir => buflist
-    silent! ls
+    silent execute l:ls_cli
     redir END
     let bids = []
     for curline in split(buflist, '\n')


### PR DESCRIPTION
Introduce g:quickui_buffer_list_cli to set the CLI and flags that used for buffer list.

The default value is 'ls t' which means show the most recently used buffers.

For more info about flags, please check :help ls