### PR TITLE
Introduce quickui_ctags_opts

### DIFF
--- a/autoload/quickui/tags.vim
+++ b/autoload/quickui/tags.vim
@@ -308,7 +308,7 @@ function! quickui#tags#ctags_function(bid, ft)
 	let ctags = get(g:, 'quickui_ctags_exe', 'ctags')
 	let filename = bufname(a:bid)
 	let extname = fnamemodify(filename, ':e')
-	let extras = get(parameters, ft, '')
+	let extras  = get(get(g:, 'quickui_ctags_opts', {}), ft, get(parameters, ft, ''))
 	let srcname = fnamemodify(filename, ':p')
 	if modified || filename == ''
 		if filename == '' || extname == ''


### PR DESCRIPTION
Introduce g:quickui_ctags_opts to set language specific ctags opts (instead of hard coded parameters), the format is the same as g:Lf_CtagsFuncOpts in [Leaderf#202](https://github.com/Yggdroot/LeaderF/pull/202)

For example, you can duplicate the same output through:
let g:quickui_ctags_opts = get(g:, 'Lf_CtagsFuncOpts', {})