### PR TITLE
Fix using an invalid scratch buffer

### DIFF
--- a/autoload/quickui/core.vim
+++ b/autoload/quickui/core.vim
@@ -470,7 +470,7 @@ function! quickui#core#scratch_buffer(name, textlist)
 	else
 		let bid = -1
 	endif
-	if bid < 0
+	if bid < 0 || (g:quickui#core#has_nvim != 0 && !nvim_buf_is_valid(bid))
 		let bid = quickui#core#buffer_alloc()
 		if a:name != ''
 			let s:buffer_cache[a:name] = bid


### PR DESCRIPTION
There was an issue where opening, closing, and reopening Terminal in Neovim would access a buffer that had already been “wiped”.